### PR TITLE
Add Authors

### DIFF
--- a/draft-ramseyer-grow-peering-api.md
+++ b/draft-ramseyer-grow-peering-api.md
@@ -370,10 +370,12 @@ This document has no IANA actions.
 # Acknowledgments
 The authors would like to thank their collaborators, who implemented API versions and provided valuable feedback on the design.
 * Ben Blaustein (Meta)
+* Jakub Heichman (Meta)
 * Stefan Prattner (20c)
 * Ben Ryall (Meta)
 * Erica Salvaneschi (Cloudflare)
 * Job Snijders (Fastly)
+* David Tuber (Cloudflare)
 
 
 {:numbered="false"}


### PR DESCRIPTION
Add authors and collaborators.
I listed us all alphabetically.

@caguado did you want to be listed as "AWS" or as "Amazon"?
@grizz did you want "FullCtl" or "20c"?  I put you as FullCtl and Stefan as 20c, but maybe you want them to match?
