### PR TITLE
add ascii art

### DIFF
--- a/draft-ramseyer-grow-peering-api.md
+++ b/draft-ramseyer-grow-peering-api.md
@@ -129,6 +129,8 @@ Example Request Flow
 --------------------
 For a diagram, please see: https://github.com/bgp/autopeer/blob/main/README.md#sequence-diagram
 
+
+~~~~~~~~~~
 OIDC Authentication
 
 +-----------+                 +-------+                    +-----------+
@@ -183,7 +185,7 @@ Request session status
       |                                  Reply with session status |
       |                                      (200, 404, 202, etc.) |
       |<-----------------------------------------------------------|
-
+~~~~~~~~~~
 
 
 AUTH    {#auth}


### PR DESCRIPTION
Add ascii representations of the mermaid docs. They are hand made and I'm not sure it makes sense to diagram more than the Auth loop part.

It does look like we can have the svg rendered for the html views [0], using our github actions template [1]. Should we look at adding both or leave it as is for the first version?

[0] https://authors.ietf.org/diagrams
[1] https://github.com/cabo/kramdown-rfc/wiki/SVG



