### PR TITLE
Update acknowledgements

### DIFF
--- a/draft-ietf-grow-peering-api.md
+++ b/draft-ietf-grow-peering-api.md
@@ -674,15 +674,16 @@ Acknowledgments     {#acknowledgments}
 
 The authors would like to thank their collaborators, who implemented API versions and provided valuable feedback on the design.
 
-* Ben Blaustein (Meta)
+* Ben Blaustein 
 * Jakub Heichman (Meta)
+* Prithvi Nath Manikonda (Amazon)
+* Q Misell (Glauca Digital)
 * Stefan Pratter (20C)
+* Aaron Rose (Amazon)
 * Ben Ryall (Meta)
 * Erica Salvaneschi (Cloudflare)
-* Job Snijders (Fastly)
+* Job Snijders 
 * David Tuber (Cloudflare)
-* Aaron Rose (Amazon)
-* Prithvi Nath Manikonda (Amazon)
 * Matthias Wichtlhuber (DE-CIX)
 
 

--- a/draft-ietf-grow-peering-api.md
+++ b/draft-ietf-grow-peering-api.md
@@ -674,7 +674,7 @@ Acknowledgments     {#acknowledgments}
 
 The authors would like to thank their collaborators, who implemented API versions and provided valuable feedback on the design.
 
-* Ben Blaustein 
+* Ben Blaustein
 * Jakub Heichman (Meta)
 * Prithvi Nath Manikonda (Amazon)
 * Q Misell (Glauca Digital)
@@ -682,7 +682,7 @@ The authors would like to thank their collaborators, who implemented API version
 * Aaron Rose (Amazon)
 * Ben Ryall (Meta)
 * Erica Salvaneschi (Cloudflare)
-* Job Snijders 
+* Job Snijders
 * David Tuber (Cloudflare)
 * Matthias Wichtlhuber (DE-CIX)
 


### PR DESCRIPTION
In the event that we publish a new version for the next meeting, without having merged in https://github.com/bgp/draft-ietf-peering-api/pull/30, we should update the acknowledgements anyway.

I checked the latest build, and it looks like everything is working, so we should be ok to post a new version.

Reordered the acknowledgements to bring it closer to alphabetical